### PR TITLE
Require absolute import in kerberos.py.  

### DIFF
--- a/requests_kerberos/kerberos.py
+++ b/requests_kerberos/kerberos.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from requests.auth import AuthBase
 from requests.compat import urlparse
 import kerberos


### PR DESCRIPTION
In 2.7 relative imports are the default, so referencing the name "kerberos" in the code
turns into a mess.  See https://github.com/requests/requests-kerberos/issues/8.

This fix simply requires absolute imports.  This makes it so that
"import kerberos" will always refer to the kerberos package/shared
library, and not the requests_kerberos.kerberos module.

It doesn't seem to break anything else currently.
