### PR TITLE
Setup.py breaks if kerberos is not already installed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 from setuptools import setup
 
-import requests_kerberos
+import compiler
 
 with open('requirements.txt') as requirements:
     requires = [line.strip() for line in requirements if line.strip()]
@@ -21,6 +21,23 @@ if os.path.isfile(desc_fd):
 if os.path.isfile(hist_fd):
     long_desc = '\n\n'.join([long_desc, open(hist_fd).read()])
 
+# It seems like per the requests module, we'd like to get the version
+# from __init__.py however, __init__.py will import the kerberos
+# module.  The kerberos module may not be installed - and when it's
+# not, it's pulled in by the requirements.txt.  When it's being
+# installed, however, this setup.py is evaluated before the
+# kerberos.so module is built and installed, and this bombs.
+#
+# To fix this, we can use the compiler module to parse __init__.py,
+# and as long as __version__ is defined as a constant so that we
+# don't have to evaluate it to get the value, we can do some dubious
+# groping arond the AST and get the version from that
+parsed = compiler.parseFile('requests_kerberos/__init__.py')    
+for n in parsed.getChildNodes()[0]:
+    if 'nodes' in dir(n): 
+        if n.nodes[0].name == '__version__':
+            my_version = n.expr.value        
+    
 setup(
     name='requests-kerberos',
     description=short_desc,
@@ -29,6 +46,6 @@ setup(
     packages=['requests_kerberos'],
     package_data={'': ['LICENSE', 'AUTHORS']},
     include_package_data=True,
-    version=requests_kerberos.__version__,  # NOQA
+    version = my_version,
     install_requires=requires,
 )


### PR DESCRIPTION
When trying to install requests-kerberos setup.py cannot import
requests_kerberos.  Doing this causes a problem where requirements.txt
causes kerberos to be downloaded.  However, it is not yet installed
when requests-kerberos's setup.py is evaluated.  Since setup.py
imports requests_kerberos, and requests_kerberos import kerberos, the
installation fails.

See https://gist.github.com/pcn/5209734 for an example.

This commit fixes the problem by using the compiler module to parse
__init__.py, but doesn't evaluate it.  It then searches for the node
whose name is __version__ and uses the constant that would be assigned
to it for setup.py.

It does mean that version has to be a constant.  I don't think that'd
be a problem.

It also means that if there is any other symbol with the name __version__
it'll complicate this.
