### PR TITLE
Cannot access website if the url contains the port

### DIFF
--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -92,7 +92,7 @@ class HTTPKerberosAuth(AuthBase):
         If any GSSAPI step fails, return None.
 
         """
-        host = urlparse(response.url).netloc
+        host = urlparse(response.url).hostname
 
         try:
             result, self.context[host] = kerberos.authGSSClientInit(
@@ -220,7 +220,7 @@ class HTTPKerberosAuth(AuthBase):
         log.debug("authenticate_server(): Authenticate header: {0}".format(
             _negotiate_value(response)))
 
-        host = urlparse(response.url).netloc
+        host = urlparse(response.url).hostname
 
         try:
             result = kerberos.authGSSClientStep(self.context[host],


### PR DESCRIPTION
While accessing a protected site with kerberos authentication if the url contains a port it crashes in kerberos_.py:98 during the creation of the kerberos token.

This is because when calculating the host it gets also the port attached in kerberos_.py:95 and in kerberos_.py:223

host = urlparse(response.url).netloc

for a url 'http://www.example.com:8080/site' it returns as host 'www.example.com:8080'
if you replace netloc by hostname you obtain the desired behaviour discarding ports

host = urlparse(response.url).hostname
