### PR TITLE
Update requirements to depend on requests>=1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==1.1.0
+requests>=1.1.0
 kerberos==1.1.1


### PR DESCRIPTION
The latest version of requests is 1.2.3 and pinning requests-kerberos's
required version to exactly 1.1.0 means it can't be used by an app that
already has a pinned requirement on requests 1.2.3

Refs #14
