### PR TITLE
Add support for delegating credentials.

### DIFF
--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -81,9 +81,10 @@ def _negotiate_value(response):
 class HTTPKerberosAuth(AuthBase):
     """Attaches HTTP GSSAPI/Kerberos Authentication to the given Request
     object."""
-    def __init__(self, mutual_authentication=REQUIRED):
+    def __init__(self, mutual_authentication=REQUIRED, delegate=False):
         self.context = {}
         self.mutual_authentication = mutual_authentication
+        self.delegate = delegate
 
     def generate_request_header(self, response):
         """
@@ -94,9 +95,14 @@ class HTTPKerberosAuth(AuthBase):
         """
         host = urlparse(response.url).hostname
 
+        # Flags used by kerberos module.
+        gssflags = kerberos.GSS_C_MUTUAL_FLAG|kerberos.GSS_C_SEQUENCE_FLAG
+        if self.delegate:
+        	gssflags |= kerberos.GSS_C_DELEG_FLAG
+
         try:
             result, self.context[host] = kerberos.authGSSClientInit(
-                "HTTP@{0}".format(host))
+                "HTTP@{0}".format(host), gssflags = gssflags)
         except kerberos.GSSError as e:
             log.error("generate_request_header(): authGSSClientInit() failed:")
             log.exception(e)


### PR DESCRIPTION
Pass GSS_C_DELEG_FLAG when delegation is requested.  This is needed when using Apache mod_auth_kerb's KrbSaveCredentials option.  Credentials must be forwardable and delegated in order to save then in a credentials cache.