### PR TITLE
Add dependenices to enable './setup.py test' command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,4 +48,6 @@ setup(
     include_package_data=True,
     version = my_version,
     install_requires=requires,
+    test_suite='test_requests_kerberos',
+    tests_require=['mock'],
 )


### PR DESCRIPTION
mock module is required
tell setuptools where the tests are
