### PR TITLE
Allow subclasses to override service name HTTP

### DIFF
--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -81,6 +81,7 @@ def _negotiate_value(response):
 class HTTPKerberosAuth(AuthBase):
     """Attaches HTTP GSSAPI/Kerberos Authentication to the given Request
     object."""
+    service = 'HTTP'
     def __init__(self, mutual_authentication=REQUIRED):
         self.context = {}
         self.mutual_authentication = mutual_authentication
@@ -97,7 +98,7 @@ class HTTPKerberosAuth(AuthBase):
 
         try:
             result, self.context[host] = kerberos.authGSSClientInit(
-                "HTTP@{0}".format(host))
+                "{0}@{1}".format(self.service, host))
         except kerberos.GSSError as e:
             log.error("generate_request_header(): authGSSClientInit() failed:")
             log.exception(e)


### PR DESCRIPTION
This is an alternate mechanism by which users in-the-know can override the primary/service name used to construct the service principal when initiating authentication. 

They subclass HTTPKerberosAuth and set the class property 'service' to whatever they desire. This will make sure that new users don't have to deal with any confusing options, but let advanced users have an easy way to override the defaults.

This is in response to https://github.com/requests/requests-kerberos/pull/27
