### PR TITLE
Add Windows native authentication support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ python:
     - "2.6"
     - "2.7"
 
+install:
+    - pip install .
 script: py.test test_requests_kerberos.py

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -1,4 +1,7 @@
-import kerberos
+try:
+    import kerberos
+except ImportError:
+    import kerberos_sspi as kerberos
 import re
 import logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests>=1.1.0
-kerberos==1.1.1

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python
 # coding: utf-8
 import os
+import sys
 import re
 from setuptools import setup
 
 with open('requirements.txt') as requirements:
     requires = [line.strip() for line in requirements if line.strip()]
+
+if sys.platform == 'win32':
+    requires.append('kerberos-sspi')
+else:
+    requires.append('kerberos==1.1.1')
 
 path = os.path.dirname(__file__)
 desc_fd = os.path.join(path, 'README.rst')


### PR DESCRIPTION
Add kerberos-sspi as an alternative backend.
[kerberos-sspi](https://github.com/may-day/kerberos-sspi) package is an API level equivalent with kerberos
package but uses windows sspi (through pywin32)

