### PR TITLE
Switch requirement to pykerberos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=1.1.0
-kerberos==1.1.1
+pykerberos


### PR DESCRIPTION
Previously requirements.txt declared a requirement on
kerberos==1.1.1.  However, pykerberos is more active
upstream.  We also remove the version tracking as the
current minimum version on pypi is functional.

Therefore switching to that, which closes #37

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>