### PR TITLE
Prevent infinite recursion when GSSErrors occurs

### DIFF
--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -99,9 +99,8 @@ class HTTPKerberosAuth(AuthBase):
         try:
             result, self.context[host] = kerberos.authGSSClientInit(
                 "{0}@{1}".format(self.service, host))
-        except kerberos.GSSError as e:
-            log.error("generate_request_header(): authGSSClientInit() failed:")
-            log.exception(e)
+        except kerberos.GSSError:
+            log.exception("generate_request_header(): authGSSClientInit() failed:")
             return None
 
         if result < 1:
@@ -112,9 +111,8 @@ class HTTPKerberosAuth(AuthBase):
         try:
             result = kerberos.authGSSClientStep(self.context[host],
                                                 _negotiate_value(response))
-        except kerberos.GSSError as e:
-            log.error("generate_request_header(): authGSSClientStep() failed:")
-            log.exception(e)
+        except kerberos.GSSError:
+            log.exception("generate_request_header(): authGSSClientStep() failed:")
             return None
 
         if result < 0:
@@ -124,10 +122,9 @@ class HTTPKerberosAuth(AuthBase):
 
         try:
             gss_response = kerberos.authGSSClientResponse(self.context[host])
-        except kerberos.GSSError as e:
-            log.error("generate_request_header(): authGSSClientResponse() "
+        except kerberos.GSSError:
+            log.exception("generate_request_header(): authGSSClientResponse() "
                       "failed:")
-            log.exception(e)
             return None
 
         return "Negotiate {0}".format(gss_response)
@@ -227,9 +224,8 @@ class HTTPKerberosAuth(AuthBase):
         try:
             result = kerberos.authGSSClientStep(self.context[host],
                                                 _negotiate_value(response))
-        except kerberos.GSSError as e:
-            log.error("authenticate_server(): authGSSClientStep() failed:")
-            log.exception(e)
+        except kerberos.GSSError:
+            log.exception("authenticate_server(): authGSSClientStep() failed:")
             return False
 
         if result < 1:


### PR DESCRIPTION
When calling log.exception you do not need to pass an exception object,
it will fetch it from the stack automatically. Passing the exception
object in results in infinite recursion.

```
  File ".../lib/python2.6/site-packages/requests_kerberos/kerberos_.py", line 117, in generate_request_header
    log.exception(e)
  File "/usr/lib64/python2.6/logging/__init__.py", line 1088, in exception
    self.error(*((msg,) + args), **{'exc_info': 1})
  File "/usr/lib64/python2.6/logging/__init__.py", line 1082, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/usr/lib64/python2.6/logging/__init__.py", line 1173, in _log
    self.handle(record)
  File "/usr/lib64/python2.6/logging/__init__.py", line 1183, in handle
    self.callHandlers(record)
  File "/usr/lib64/python2.6/logging/__init__.py", line 1220, in callHandlers
    hdlr.handle(record)
  File "/usr/lib64/python2.6/logging/__init__.py", line 679, in handle
    self.emit(record)
  File "/usr/lib64/python2.6/logging/__init__.py", line 804, in emit
    self.handleError(record)
  File "/usr/lib64/python2.6/logging/__init__.py", line 733, in handleError
    traceback.print_exception(ei[0], ei[1], ei[2], None, sys.stderr)
  File "/usr/lib64/python2.6/traceback.py", line 126, in print_exception
    lines = format_exception_only(etype, value)
  File "/usr/lib64/python2.6/traceback.py", line 179, in format_exception_only
    return [_format_final_exc_line(stype, value)]
  File "/usr/lib64/python2.6/traceback.py", line 205, in _format_final_exc_line
    valuestr = _some_str(value)
  File "/usr/lib64/python2.6/traceback.py", line 214, in _some_str
    return str(value)
RuntimeError: maximum recursion depth exceeded while getting the str of an object
```
