### PR TITLE
Fix HTTPKerberosAuth not to treat non-file as a file

### DIFF
--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -262,5 +262,9 @@ class HTTPKerberosAuth(AuthBase):
         try:
             self.pos = request.body.tell()
         except AttributeError:
-            pass
+            # In the case of HTTPKerberosAuth being reused and the body
+            # of the previous request was a file-like object, pos has
+            # the file position of the previous body. Ensure it's set to
+            # None.
+            self.pos = None
         return request


### PR DESCRIPTION
Ensure pos is set to None when the body is not a file
so that HTTPKerberosAuth detects the type of the body correctly.
