### PR TITLE
Prevent infinite recursion when server responds with 401 to an authentication attempt.

### DIFF
--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -245,13 +245,14 @@ class HTTPKerberosAuth(AuthBase):
             response.request.body.seek(self.pos)
 
         if response.status_code == 401:
+            # 401 Unauthorized. Handle it, and if it still comes back as 401,
+            # that means authentication failed.
             _r = self.handle_401(response, **kwargs)
-            log.debug("handle_response(): returning {0}".format(_r))
-            return self.handle_response(_r, **kwargs)
         else:
             _r = self.handle_other(response)
-            log.debug("handle_response(): returning {0}".format(_r))
-            return _r
+            
+        log.debug("handle_response(): returning {0}".format(_r))
+        return _r
 
     def deregister(self, response):
         """Deregisters the response handler"""

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -238,21 +238,25 @@ class HTTPKerberosAuth(AuthBase):
 
     def handle_response(self, response, **kwargs):
         """Takes the given response and tries kerberos-auth, as needed."""
+        num_401s = kwargs.pop('num_401s', 0)
 
         if self.pos is not None:
             # Rewind the file position indicator of the body to where
             # it was to resend the request.
             response.request.body.seek(self.pos)
 
-        if response.status_code == 401:
+        if response.status_code == 401 and num_401s < 2:
             # 401 Unauthorized. Handle it, and if it still comes back as 401,
             # that means authentication failed.
             _r = self.handle_401(response, **kwargs)
+            log.debug("handle_response(): returning %s", _r)
+            log.debug("handle_response() has seen %d 401 responses", num_401s)
+            num_401s += 1
+            return self.handle_response(_r, num_401s=num_401s, **kwargs)
         else:
             _r = self.handle_other(response)
-            
-        log.debug("handle_response(): returning {0}".format(_r))
-        return _r
+            log.debug("handle_response(): returning %s", _r)
+            return _r
 
     def deregister(self, response):
         """Deregisters the response handler"""

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -253,6 +253,11 @@ class HTTPKerberosAuth(AuthBase):
             log.debug("handle_response() has seen %d 401 responses", num_401s)
             num_401s += 1
             return self.handle_response(_r, num_401s=num_401s, **kwargs)
+        elif response.status_code == 401 and num_401s >= 2:
+            # Still receiving 401 responses after attempting to handle them.
+            # Authentication has failed. Return the 401 response.
+            log.debug("handle_response(): returning 401 %s", response)
+            return response
         else:
             _r = self.handle_other(response)
             log.debug("handle_response(): returning %s", _r)

--- a/test_requests_kerberos.py
+++ b/test_requests_kerberos.py
@@ -377,6 +377,7 @@ class KerberosTestCase(unittest.TestCase):
 
 
     def test_handle_response_401(self):
+        # Get a 401 from server, authenticate, and get a 200 back.
         with patch.multiple('kerberos',
                             authGSSClientInit=clientInit_complete,
                             authGSSClientResponse=clientResponse,
@@ -404,13 +405,52 @@ class KerberosTestCase(unittest.TestCase):
             response.raw = raw
 
             auth = requests_kerberos.HTTPKerberosAuth()
-            auth.handle_other = Mock(return_value=response_ok)
 
             r = auth.handle_response(response)
 
             self.assertTrue(response in r.history)
-            auth.handle_other.assert_called_with(response_ok)
             self.assertEqual(r, response_ok)
+            self.assertEqual(request.headers['Authorization'], 'Negotiate GSSRESPONSE')
+            connection.send.assert_called_with(request)
+            raw.release_conn.assert_called_with()
+            clientInit_complete.assert_called_with("HTTP@www.example.org")
+            clientStep_continue.assert_called_with("CTX", "token")
+            clientResponse.assert_called_with("CTX")
+            
+    def test_handle_response_401_rejected(self):
+        # Get a 401 from server, authenticate, and get another 401 back.
+        # Ensure there is no infinite recursion.
+        with patch.multiple('kerberos',
+                            authGSSClientInit=clientInit_complete,
+                            authGSSClientResponse=clientResponse,
+                            authGSSClientStep=clientStep_continue):
+                            
+            response_auth_reject = requests.Response()
+            response_auth_reject.url = "http://www.example.org/"
+            response_auth_reject.status_code = 401
+
+            connection = Mock()
+            connection.send = Mock(return_value=response_auth_reject)
+
+            raw = Mock()
+            raw.release_conn = Mock(return_value=None)
+
+            request = requests.Request()
+            response = requests.Response()
+            response.request = request
+            response.url = "http://www.example.org/"
+            response.headers = {'www-authenticate': 'negotiate token'}
+            response.status_code = 401
+            response.connection = connection
+            response._content = ""
+            response.raw = raw
+
+            auth = requests_kerberos.HTTPKerberosAuth()
+
+            r = auth.handle_response(response)
+
+            self.assertTrue(response in r.history)
+            self.assertEqual(r, response_auth_reject)
             self.assertEqual(request.headers['Authorization'], 'Negotiate GSSRESPONSE')
             connection.send.assert_called_with(request)
             raw.release_conn.assert_called_with()

--- a/test_requests_kerberos.py
+++ b/test_requests_kerberos.py
@@ -405,10 +405,12 @@ class KerberosTestCase(unittest.TestCase):
             response.raw = raw
 
             auth = requests_kerberos.HTTPKerberosAuth()
+            auth.handle_other = Mock(return_value=response_ok)
 
             r = auth.handle_response(response)
 
             self.assertTrue(response in r.history)
+            auth.handle_other.assert_called_once_with(response_ok)
             self.assertEqual(r, response_ok)
             self.assertEqual(request.headers['Authorization'], 'Negotiate GSSRESPONSE')
             connection.send.assert_called_with(request)
@@ -424,16 +426,20 @@ class KerberosTestCase(unittest.TestCase):
                             authGSSClientInit=clientInit_complete,
                             authGSSClientResponse=clientResponse,
                             authGSSClientStep=clientStep_continue):
-                            
-            response_auth_reject = requests.Response()
-            response_auth_reject.url = "http://www.example.org/"
-            response_auth_reject.status_code = 401
 
             connection = Mock()
-            connection.send = Mock(return_value=response_auth_reject)
+
+            def connection_send(self, *args, **kwargs):
+                reject = requests.Response()
+                reject.url = "http://www.example.org/"
+                reject.status_code = 401
+                reject.connection = connection
+                return reject
+
+            connection.send.side_effect = connection_send
 
             raw = Mock()
-            raw.release_conn = Mock(return_value=None)
+            raw.release_conn.return_value = None
 
             request = requests.Request()
             response = requests.Response()
@@ -449,9 +455,9 @@ class KerberosTestCase(unittest.TestCase):
 
             r = auth.handle_response(response)
 
-            self.assertTrue(response in r.history)
-            self.assertEqual(r, response_auth_reject)
-            self.assertEqual(request.headers['Authorization'], 'Negotiate GSSRESPONSE')
+            self.assertEqual(r.status_code, 401)
+            self.assertEqual(request.headers['Authorization'],
+                             'Negotiate GSSRESPONSE')
             connection.send.assert_called_with(request)
             raw.release_conn.assert_called_with()
             clientInit_complete.assert_called_with("HTTP@www.example.org")


### PR DESCRIPTION
I found that requests-kerberos recurses until it blows the stack in the case where:

1. Server responds with 401 Unauthorized.
2. requests-kerberos retries the request with an Authorization header.
3. Server responds with 401 again, because the authenticated user has not been granted access.

This pull request changes the behaviour such that the response to `handle_401()` is returned with no further processing.

Tested with SharePoint Server 2013.