### PR TITLE
Stop logging on otherwise acceptable responses

### DIFF
--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -191,8 +191,9 @@ class HTTPKerberosAuth(AuthBase):
                 return response
 
             elif is_http_error or self.mutual_authentication == OPTIONAL:
-                log.error("handle_other(): Mutual authentication unavailable "
-                          "on {0} response".format(response.status_code))
+                if not response.ok:
+                    log.error("handle_other(): Mutual authentication unavailable "
+                              "on {0} response".format(response.status_code))
 
                 if self.mutual_authentication == REQUIRED:
                     return SanitizedResponse(response)


### PR DESCRIPTION
cloudera/hue developers were seeing a large number of log errors for
200 status code responses. Instead of slowly growing a list of status codes
to not log an error message for, let's just not log the message if the response
code is "ok" (`200 <= status_code < 400`, vaguely speaking).