### PR TITLE
relax version in kerberos requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('requirements.txt') as requirements:
 if sys.platform == 'win32':
     requires.append('kerberos-sspi')
 else:
-    requires.append('kerberos==1.1.1')
+    requires.append('kerberos')
 
 path = os.path.dirname(__file__)
 desc_fd = os.path.join(path, 'README.rst')


### PR DESCRIPTION
Any version of the kerberos module should work fine, it has had no API changes in living memory as far as I can see.