### PR TITLE
Uses kerberos_sspi on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def get_version():
     """
     reg = re.compile(r'__version__ = [\'"]([^\'"]*)[\'"]')
     with open('requests_kerberos/__init__.py') as fd:
-        matches = filter(lambda x: x, map(reg.match, fd))
+        matches = list(filter(lambda x: x, map(reg.match, fd)))
 
     if not matches:
         raise RuntimeError(


### PR DESCRIPTION
This is an attempt to fix #51.

It was done and validated on Windows aith Python 3.4 installed through anaconda.
I lack experience in compatibility issue between python 2 and python 3 : your guidance in how to reach an acceptable patch is more then welcome :-)
