### PR TITLE
Fix dependency for kerberos-sspi on Windows; else use pykerberos. (Fixes #51, #38)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=1.1.0
 kerberos-sspi >= 0.2; sys.platform == 'win32'
-pykerberos >= 1.1.1, < 2.0.0; sys.platform != 'win32'
+pykerberos >= 1.1.8, < 2.0.0; sys.platform != 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests>=1.1.0
+kerberos-sspi >= 0.2; sys.platform == 'win32'
+pykerberos >= 1.1.1, < 2.0.0; sys.platform != 'win32'

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
     extras_require={
         ':sys_platform=="win32"': ['kerberos-sspi>=0.2'],
-        ':sys_platform!="win32"': ['pykerberos>=1.1.1,<2.0.0'],
+        ':sys_platform!="win32"': ['pykerberos>=1.1.8,<2.0.0'],
     },
     test_suite='test_requests_kerberos',
     tests_require=['mock'],

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,8 @@
 #!/usr/bin/env python
 # coding: utf-8
 import os
-import sys
 import re
 from setuptools import setup
-
-with open('requirements.txt') as requirements:
-    requires = [line.strip() for line in requirements if line.strip()]
-
-if sys.platform == 'win32':
-    requires.append('kerberos-sspi')
-else:
-    requires.append('kerberos==1.1.1')
 
 path = os.path.dirname(__file__)
 desc_fd = os.path.join(path, 'README.rst')
@@ -56,7 +47,13 @@ setup(
     package_data={'': ['LICENSE', 'AUTHORS']},
     include_package_data=True,
     version=get_version(),
-    install_requires=requires,
+    install_requires=[
+        'requests>=1.1.0',
+    ],
+    extras_require={
+        ':sys_platform=="win32"': ['kerberos-sspi>=0.2'],
+        ':sys_platform!="win32"': ['pykerberos>=1.1.1,<2.0.0'],
+    },
     test_suite='test_requests_kerberos',
     tests_require=['mock'],
 )


### PR DESCRIPTION
This change fixes the dependency issue in the whl. Now the metadata.json in the whl looks like:

```json
"run_requires": [
   {"environment": "sys_platform==\"win32\"", "requires": ["kerberos-sspi (>=0.2)"]}, 
   {"environment": "sys_platform!=\"win32\"", "requires": ["pykerberos (>=1.1.1,<2.0.0)"]}, 
   {"requires": ["requests (>=1.1.0)"]}
]
```

For PY3 support, I took the liberty of changing the *nix dependency to use `pykerberos` instead of `kerberos`, but I'm not able to test against a real Kerberos-authenticating server on *nix. I fixed the version based on the discussion in #38.

I set kerberos-sspi to >= 0.2 because 0.2 is the one that claims PY3 support, and based on the discussion in #34. It's also the only version that I've been using. In the highly unlikely (AFAIK) event that someone on Windows wants to install requests-kerberos and doesn't want to use requests-sspi because they have access to (py)kerberos, they can use `pip install --no-deps`...