### PR TITLE
Fix for mutual auth on winrm

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,19 @@ authentication, you can do that as well:
     >>> r = requests.get("http://example.org", auth=kerberos_auth)
     ...
 
+Preemptive Authentication
+-------------------------
+
+``HTTPKerberosAuth`` can be forced to preemptively initiate the Kerberos GSS exchange and present a Kerberos ticket on the initial request (and all subsequent). By default, authentication only occurs after a ``401 Unauthorized`` response containing a Kerberos or Negotiate challenge is received from the origin server. This can cause mutual authentication failures for hosts that use a persistent connection (eg, Windows/WinRM), as no Kerberos challenges are sent after the initial auth handshake. This behavior can be altered by setting  ``force_preemptive=True``:
+
+.. code-block:: pycon
+    
+    >>> import requests
+    >>> from requests_kerberos import HTTPKerberosAuth, REQUIRED
+    >>> kerberos_auth = HTTPKerberosAuth(mutual_authentication=REQUIRED, force_preemptive=True)
+    >>> r = requests.get("https://windows.example.org/wsman", auth=kerberos_auth)
+    ...
+
 Logging
 -------
 

--- a/requests_kerberos/exceptions.py
+++ b/requests_kerberos/exceptions.py
@@ -10,3 +10,6 @@ from requests.exceptions import RequestException
 
 class MutualAuthenticationError(RequestException):
     """Mutual Authentication Error"""
+
+class KerberosExchangeError(RequestException):
+    """Kerberos Exchange Failed Error"""


### PR DESCRIPTION
Fixes #68.

Existing code doesn't work with Windows Negotiate if mutual_auth is REQUIRED, since current code stops sending Authorization headers after success, but Windows keeps a persistent connection and stops sending WWW-Authenticate responses. This change allows Kerberos auth to be forced on each request by setting force_preemptive=True (defaults to False). 

Also "accidentally" fixes #65, since we needed a way to preemptively auth on every request anyway.

Updated existing tests to pass with changed internal args, but haven't added tests for new functionality yet. This is obviously "work in progress"- if the approach is sound, I'll add tests and clean up other things.