### PR TITLE
Block use of `principal` argument when using kerberos-sspi. Fixes #71.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,10 @@ builds). An explicit principal can be specified with the ``principal`` arg:
     >>> kerberos_auth = HTTPKerberosAuth(principal="user@REALM")
     >>> r = requests.get("http://example.org", auth=kerberos_auth)
     ...
+    
+**Windows users:** Explicit Principal is currently not supported when using 
+``kerberos-sspi``. Providing a value for ``principal`` in this scenario will raise
+``NotImplementedError``.
 
 Logging
 -------

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -122,12 +122,12 @@ class HTTPKerberosAuth(AuthBase):
             kerb_host = self.hostname_override if self.hostname_override is not None else host
             kerb_spn = "{0}@{1}".format(self.service, kerb_host)
             
-            kwargs = {'principal': self.principal}
+            kwargs = {}
             # kerberos-sspi: Never pass principal. Raise if user tries to specify one.
-            if self._using_kerberos_sspi:
-                kwargs = {}
-                if self.principal:
-                    raise NotImplementedError("Can't use 'principal' argument with kerberos-sspi.")
+            if not self._using_kerberos_sspi:
+                kwargs['principal'] = self.principal
+            elif self.principal:
+                raise NotImplementedError("Can't use 'principal' argument with kerberos-sspi.")
 
             result, self.context[host] = kerberos.authGSSClientInit(kerb_spn,
                 gssflags=gssflags, **kwargs)

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -123,8 +123,11 @@ class HTTPKerberosAuth(AuthBase):
             kerb_spn = "{0}@{1}".format(self.service, kerb_host)
             
             kwargs = {'principal': self.principal}
-            if self._using_kerberos_sspi and self.principal:
-                raise NotImplementedError("Can't use 'principal' argument with kerberos-sspi.")
+            # kerberos-sspi: Never pass principal. Raise if user tries to specify one.
+            if self._using_kerberos_sspi:
+                kwargs = {}
+                if self.principal:
+                    raise NotImplementedError("Can't use 'principal' argument with kerberos-sspi.")
 
             result, self.context[host] = kerberos.authGSSClientInit(kerb_spn,
                 gssflags=gssflags, **kwargs)

--- a/test_requests_kerberos.py
+++ b/test_requests_kerberos.py
@@ -640,6 +640,16 @@ class KerberosTestCase(unittest.TestCase):
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
                 principal=None)
+    
+    def test_kerberos_sspi_reject_principal(self):
+        response = requests.Response()
+        response.url = "http://www.example.org/"
+        host = urlparse(response.url).hostname
+           
+        auth = requests_kerberos.HTTPKerberosAuth(principal="user@REALM")
+        auth._using_kerberos_sspi = True
+        with self.assertRaises(NotImplementedError):
+            auth.generate_request_header(response, host)
 
 
 if __name__ == '__main__':

--- a/test_requests_kerberos.py
+++ b/test_requests_kerberos.py
@@ -653,8 +653,7 @@ class KerberosTestCase(unittest.TestCase):
            
         auth = requests_kerberos.HTTPKerberosAuth(principal="user@REALM")
         auth._using_kerberos_sspi = True
-        with self.assertRaises(NotImplementedError):
-            auth.generate_request_header(response, host)
+        self.assertRaises(NotImplementedError, auth.generate_request_header, response, host)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The goal here is to avoid passing the `principal` keyword argument that's unrecognized by kerberos-sspi, while gracefully failing if someone tries to use it with kerberos-sspi / Windows.

This is a holdover until I get around to trying out WinKerberos as the successor to kerberos-sspi + pywin32.