### PR TITLE
Replace kerberos-sspi with WinKerberos. Fixes #67.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,10 +131,6 @@ builds). An explicit principal can be specified with the ``principal`` arg:
     >>> kerberos_auth = HTTPKerberosAuth(principal="user@REALM")
     >>> r = requests.get("http://example.org", auth=kerberos_auth)
     ...
-    
-**Windows users:** Explicit Principal is currently not supported when using 
-``kerberos-sspi``. Providing a value for ``principal`` in this scenario will raise
-``NotImplementedError``.
 
 Logging
 -------

--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ whom you last ran ``kinit`` or ``kswitch``, or an SSO credential if
 applicable). However, an explicit principal can be specified, which will
 cause Kerberos to look for a matching credential cache for the named user.
 This feature depends on OS support for collection-type credential caches,
-as well as working principal support in pykerberos (it is broken in many
+as well as working principal support in PyKerberos (it is broken in many
 builds). An explicit principal can be specified with the ``principal`` arg:
 
 .. code-block:: python
@@ -131,6 +131,10 @@ builds). An explicit principal can be specified with the ``principal`` arg:
     >>> kerberos_auth = HTTPKerberosAuth(principal="user@REALM")
     >>> r = requests.get("http://example.org", auth=kerberos_auth)
     ...
+
+On Windows, WinKerberos is used instead of PyKerberos. WinKerberos allows the
+use of arbitrary principals instead of a credential cache. Passwords can be
+specified by following the form ``user@realm:password`` for ``principal``.
 
 Logging
 -------

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -1,9 +1,7 @@
 try:
     import kerberos
-    using_kerberos_sspi = False
 except ImportError:
     import kerberos_sspi as kerberos
-    using_kerberos_sspi = True
 import re
 import logging
 
@@ -97,7 +95,6 @@ class HTTPKerberosAuth(AuthBase):
         self.principal = principal
         self.hostname_override = hostname_override
         self.sanitize_mutual_error_response = sanitize_mutual_error_response
-        self._using_kerberos_sspi = using_kerberos_sspi
 
     def generate_request_header(self, response, host, is_preemptive=False):
         """
@@ -121,16 +118,9 @@ class HTTPKerberosAuth(AuthBase):
             # w/ name-based HTTP hosting)
             kerb_host = self.hostname_override if self.hostname_override is not None else host
             kerb_spn = "{0}@{1}".format(self.service, kerb_host)
-            
-            kwargs = {}
-            # kerberos-sspi: Never pass principal. Raise if user tries to specify one.
-            if not self._using_kerberos_sspi:
-                kwargs['principal'] = self.principal
-            elif self.principal:
-                raise NotImplementedError("Can't use 'principal' argument with kerberos-sspi.")
 
             result, self.context[host] = kerberos.authGSSClientInit(kerb_spn,
-                gssflags=gssflags, **kwargs)
+                gssflags=gssflags, principal=self.principal)
 
             if result < 1:
                 raise EnvironmentError(result, kerb_stage)

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -1,7 +1,7 @@
 try:
     import kerberos
 except ImportError:
-    import kerberos_sspi as kerberos
+    import winkerberos as kerberos
 import re
 import logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=1.1.0
-winkerberos >= 0.4.0; sys.platform == 'win32'
+winkerberos >= 0.5.0; sys.platform == 'win32'
 pykerberos >= 1.1.8, < 2.0.0; sys.platform != 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=1.1.0
-kerberos-sspi >= 0.2; sys.platform == 'win32'
+winkerberos >= 0.3.0; sys.platform == 'win32'
 pykerberos >= 1.1.8, < 2.0.0; sys.platform != 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=1.1.0
-winkerberos >= 0.3.0; sys.platform == 'win32'
+winkerberos >= 0.4.0; sys.platform == 'win32'
 pykerberos >= 1.1.8, < 2.0.0; sys.platform != 'win32'

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'requests>=1.1.0',
     ],
     extras_require={
-        ':sys_platform=="win32"': ['winkerberos>=0.3.0'],
+        ':sys_platform=="win32"': ['winkerberos>=0.4.0'],
         ':sys_platform!="win32"': ['pykerberos>=1.1.8,<2.0.0'],
     },
     test_suite='test_requests_kerberos',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'requests>=1.1.0',
     ],
     extras_require={
-        ':sys_platform=="win32"': ['winkerberos>=0.4.0'],
+        ':sys_platform=="win32"': ['winkerberos>=0.5.0'],
         ':sys_platform!="win32"': ['pykerberos>=1.1.8,<2.0.0'],
     },
     test_suite='test_requests_kerberos',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'requests>=1.1.0',
     ],
     extras_require={
-        ':sys_platform=="win32"': ['kerberos-sspi>=0.2'],
+        ':sys_platform=="win32"': ['winkerberos>=0.3.0'],
         ':sys_platform!="win32"': ['pykerberos>=1.1.8,<2.0.0'],
     },
     test_suite='test_requests_kerberos',

--- a/test_requests_kerberos.py
+++ b/test_requests_kerberos.py
@@ -568,7 +568,7 @@ class KerberosTestCase(unittest.TestCase):
                 principal=None)
 
     def test_delegation(self):
-        with patch.multiple('kerberos',
+        with patch.multiple(kerberos_module_name,
                             authGSSClientInit=clientInit_complete,
                             authGSSClientResponse=clientResponse,
                             authGSSClientStep=clientStep_continue):
@@ -624,7 +624,7 @@ class KerberosTestCase(unittest.TestCase):
             response.headers = {'www-authenticate': 'negotiate token'}
             host = urlparse(response.url).hostname
             auth = requests_kerberos.HTTPKerberosAuth(principal="user@REALM")
-            auth.generate_request_header(response, host),
+            auth.generate_request_header(response, host)
             clientInit_complete.assert_called_with(
                 "HTTP@www.example.org",
                 gssflags=(
@@ -642,7 +642,7 @@ class KerberosTestCase(unittest.TestCase):
             response.headers = {'www-authenticate': 'negotiate token'}
             host = urlparse(response.url).hostname
             auth = requests_kerberos.HTTPKerberosAuth(hostname_override="otherhost.otherdomain.org")
-            auth.generate_request_header(response, host),
+            auth.generate_request_header(response, host)
             clientInit_complete.assert_called_with(
                 "HTTP@otherhost.otherdomain.org",
                 gssflags=(

--- a/test_requests_kerberos.py
+++ b/test_requests_kerberos.py
@@ -54,12 +54,6 @@ class KerberosTestCase(unittest.TestCase):
         clientStep_error.reset_mock()
         clientStep_exception.reset_mock()
         clientResponse.reset_mock()
-        
-        # When using kerberos-sspi, we never pass principal to authGSSClientInit().
-        # This affects our repeated use of assert_called_with().
-        self.clientInit_default_principal = {'principal': None}
-        if kerberos_module_name == 'kerberos_sspi':
-            self.clientInit_default_principal = {}
 
     def tearDown(self):
         """Teardown."""
@@ -126,7 +120,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                **self.clientInit_default_principal)
+                principal=None)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
 
@@ -148,7 +142,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                **self.clientInit_default_principal)
+                principal=None)
             self.assertFalse(clientStep_continue.called)
             self.assertFalse(clientResponse.called)
 
@@ -170,7 +164,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                **self.clientInit_default_principal)
+                principal=None)
             clientStep_error.assert_called_with("CTX", "token")
             self.assertFalse(clientResponse.called)
 
@@ -215,7 +209,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                **self.clientInit_default_principal)
+                principal=None)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
 
@@ -260,7 +254,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                **self.clientInit_default_principal)
+                principal=None)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
 
@@ -501,7 +495,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                **self.clientInit_default_principal)
+                principal=None)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
 
@@ -551,7 +545,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                **self.clientInit_default_principal)
+                principal=None)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
 
@@ -571,10 +565,10 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                **self.clientInit_default_principal)
+                principal=None)
 
     def test_delegation(self):
-        with patch.multiple(kerberos_module_name,
+        with patch.multiple('kerberos',
                             authGSSClientInit=clientInit_complete,
                             authGSSClientResponse=clientResponse,
                             authGSSClientStep=clientStep_continue):
@@ -615,7 +609,7 @@ class KerberosTestCase(unittest.TestCase):
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG |
                     kerberos.GSS_C_DELEG_FLAG),
-                **self.clientInit_default_principal
+                principal=None
                 )
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
@@ -630,18 +624,13 @@ class KerberosTestCase(unittest.TestCase):
             response.headers = {'www-authenticate': 'negotiate token'}
             host = urlparse(response.url).hostname
             auth = requests_kerberos.HTTPKerberosAuth(principal="user@REALM")
-            try:
-                auth.generate_request_header(response, host)
-                clientInit_complete.assert_called_with(
-                    "HTTP@www.example.org",
-                    gssflags=(
-                        kerberos.GSS_C_MUTUAL_FLAG |
-                        kerberos.GSS_C_SEQUENCE_FLAG),
-                    principal="user@REALM")
-            except NotImplementedError:
-                # principal is not supported with kerberos-sspi.
-                if not auth._using_kerberos_sspi:
-                    raise
+            auth.generate_request_header(response, host),
+            clientInit_complete.assert_called_with(
+                "HTTP@www.example.org",
+                gssflags=(
+                    kerberos.GSS_C_MUTUAL_FLAG |
+                    kerberos.GSS_C_SEQUENCE_FLAG),
+                principal="user@REALM")
 
     def test_realm_override(self):
         with patch.multiple(kerberos_module_name,
@@ -653,35 +642,13 @@ class KerberosTestCase(unittest.TestCase):
             response.headers = {'www-authenticate': 'negotiate token'}
             host = urlparse(response.url).hostname
             auth = requests_kerberos.HTTPKerberosAuth(hostname_override="otherhost.otherdomain.org")
-            auth.generate_request_header(response, host)
+            auth.generate_request_header(response, host),
             clientInit_complete.assert_called_with(
                 "HTTP@otherhost.otherdomain.org",
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                **self.clientInit_default_principal)
-    
-    def test_kerberos_sspi_reject_principal(self):
-        with patch.multiple(kerberos_module_name,
-                            authGSSClientInit=clientInit_complete,
-                            authGSSClientResponse=clientResponse,
-                            authGSSClientStep=clientStep_continue):
-            response = requests.Response()
-            response.url = "http://www.example.org/"
-            host = urlparse(response.url).hostname
-               
-            auth = requests_kerberos.HTTPKerberosAuth(principal="user@REALM")
-            auth._using_kerberos_sspi = True
-            self.assertRaises(NotImplementedError, auth.generate_request_header, response, host)
-            
-            auth = requests_kerberos.HTTPKerberosAuth(principal=None)
-            auth._using_kerberos_sspi = True
-            auth.generate_request_header(response, host)
-            clientInit_complete.assert_called_with(
-                "HTTP@www.example.org",
-                gssflags=(
-                    kerberos.GSS_C_MUTUAL_FLAG |
-                    kerberos.GSS_C_SEQUENCE_FLAG))
+                principal=None)
 
 
 if __name__ == '__main__':

--- a/test_requests_kerberos.py
+++ b/test_requests_kerberos.py
@@ -12,8 +12,8 @@ try:
     import kerberos
     kerberos_module_name='kerberos'
 except ImportError:
-    import kerberos_sspi as kerberos # On Windows
-    kerberos_module_name='kerberos_sspi'
+    import winkerberos as kerberos  # On Windows
+    kerberos_module_name = 'winkerberos'
 
 import requests_kerberos
 import unittest


### PR DESCRIPTION
This reverts the temporary workarounds in #73, and swaps the use of kerberos-sspi with WinKerberos. It's not ready to merge, but looks promising.

@behackett The unit tests fail because WinKerberos doesn't define GSSError, a subclass of KrbError.
