### PR TITLE
Support of SPNEGO authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ env/
 build/
 dist/
 requests_kerberos.egg-info/
+.idea
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ env/
 build/
 dist/
 requests_kerberos.egg-info/
-.idea
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 History
 =======
 
-0.12.0: 2017-01-19
+0.12.0: 2017-02-14
 ------------------
 
 - Switched to PyKerberos 1.1.14 and WinKerberos 0.6.0, implemented support for SPNEGO authentication

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 History
 =======
 
+0.12.0: 2017-01-19
+------------------
+
+- Switched to WinKerberos 0.6.0 and implemented support for SPNEGO authentication
+  (just an additional parameter to a kerberos/winkerberos function call).
+
 0.11.0: 2016-11-02
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,8 +4,8 @@ History
 0.12.0: 2017-01-19
 ------------------
 
-- Switched to WinKerberos 0.6.0 and implemented support for SPNEGO authentication
-  (just an additional parameter to a kerberos/winkerberos function call).
+- Switched to PyKerberos 1.1.14 and WinKerberos 0.6.0, implemented support for SPNEGO authentication
+  (just an additional parameter to a pykerberos/winkerberos function call).
 
 0.11.0: 2016-11-02
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
-requests Kerberos/GSSAPI authentication library
+requests Kerberos/Spnego authentication library
 ===============================================
 
 Requests is an HTTP library, written in Python, for human beings. This library
-adds optional Kerberos/GSSAPI authentication support and supports mutual
+adds optional Kerberos/Spnego (GSSAPI - Linux/SSPI - Windows) authentication support and supports mutual
 authentication. Basic GET usage:
 
 
@@ -11,6 +11,11 @@ authentication. Basic GET usage:
     >>> import requests
     >>> from requests_kerberos import HTTPKerberosAuth
     >>> r = requests.get("http://example.org", auth=HTTPKerberosAuth())
+    ...
+
+    >>> import requests
+    >>> from requests_kerberos import HTTPSpnegoAuth
+    >>> r = requests.get("http://example.org", auth=HTTPSpnegoAuth())
     ...
 
 The entire ``requests.api`` should be supported.

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
-requests Kerberos/Spnego authentication library
+requests Kerberos/SPNEGO authentication library
 ===============================================
 
 Requests is an HTTP library, written in Python, for human beings. This library
-adds optional Kerberos/Spnego (GSSAPI - Linux/SSPI - Windows) authentication support and supports mutual
+adds optional Kerberos/SPNEGO (GSSAPI - Linux/SSPI - Windows) authentication support and supports mutual
 authentication. Basic GET usage:
 
 

--- a/requests_kerberos/__init__.py
+++ b/requests_kerberos/__init__.py
@@ -3,7 +3,7 @@ requests Kerberos/GSSAPI authentication library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Requests is an HTTP library, written in Python, for human beings. This library
-adds optional Kerberos/Spnego (GSSAPI - Linux/SSPI - Windows) authentication support and supports mutual
+adds optional Kerberos/SPNEGO (GSSAPI - Linux/SSPI - Windows) authentication support and supports mutual
 authentication. Basic GET usage:
 
     >>> import requests

--- a/requests_kerberos/__init__.py
+++ b/requests_kerberos/__init__.py
@@ -3,23 +3,27 @@ requests Kerberos/GSSAPI authentication library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Requests is an HTTP library, written in Python, for human beings. This library
-adds optional Kerberos/GSSAPI authentication support and supports mutual
+adds optional Kerberos/Spnego (GSSAPI - Linux/SSPI - Windows) authentication support and supports mutual
 authentication. Basic GET usage:
 
     >>> import requests
     >>> from requests_kerberos import HTTPKerberosAuth
     >>> r = requests.get("http://example.org", auth=HTTPKerberosAuth())
 
+    >>> import requests
+    >>> from requests_kerberos import HTTPSpnegoAuth
+    >>> r = requests.get("http://example.org", auth=HTTPSpnegoAuth())
+
 The entire `requests.api` should be supported.
 """
 import logging
 
-from .kerberos_ import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
+from .kerberos_ import HTTPKerberosAuth, HTTPSpnegoAuth, REQUIRED, OPTIONAL, DISABLED
 from .exceptions import MutualAuthenticationError
 from .compat import NullHandler
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__all__ = ('HTTPKerberosAuth', 'MutualAuthenticationError', 'REQUIRED',
+__all__ = ('HTTPKerberosAuth', 'HTTPSpnegoAuth', 'MutualAuthenticationError', 'REQUIRED',
            'OPTIONAL', 'DISABLED')
-__version__ = '0.11.0'
+__version__ = '0.12.0'

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -334,7 +334,7 @@ class HTTPKerberosAuth(HTTPGSSAPIAuthBase):
                                     sanitize_mutual_error_response)
 
 class HTTPSpnegoAuth(HTTPGSSAPIAuthBase):
-    """Attaches HTTP GSSAPI/Spnego Authentication to the given Request
+    """Attaches HTTP GSSAPI/SPNEGO Authentication to the given Request
     object."""
     def __init__(
             self, mutual_authentication=REQUIRED,

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
     extras_require={
         ':sys_platform=="win32"': ['winkerberos>=0.6.0'],
-        ':sys_platform!="win32"': ['pykerberos>=1.1.8,<2.0.0'],
+        ':sys_platform!="win32"': ['pykerberos>=1.1.14,<2.0.0'],
     },
     test_suite='test_requests_kerberos',
     tests_require=['mock'],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'requests>=1.1.0',
     ],
     extras_require={
-        ':sys_platform=="win32"': ['winkerberos>=0.5.0'],
+        ':sys_platform=="win32"': ['winkerberos>=0.6.0'],
         ':sys_platform!="win32"': ['pykerberos>=1.1.8,<2.0.0'],
     },
     test_suite='test_requests_kerberos',

--- a/test_requests_kerberos.py
+++ b/test_requests_kerberos.py
@@ -120,6 +120,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
+                mech_oid=kerberos.GSS_MECH_OID_KRB5,
                 principal=None)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
@@ -142,6 +143,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
+                mech_oid=kerberos.GSS_MECH_OID_KRB5,
                 principal=None)
             self.assertFalse(clientStep_continue.called)
             self.assertFalse(clientResponse.called)
@@ -164,6 +166,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
+                mech_oid=kerberos.GSS_MECH_OID_KRB5,
                 principal=None)
             clientStep_error.assert_called_with("CTX", "token")
             self.assertFalse(clientResponse.called)
@@ -209,6 +212,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
+                mech_oid=kerberos.GSS_MECH_OID_KRB5,
                 principal=None)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
@@ -254,6 +258,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
+                mech_oid=kerberos.GSS_MECH_OID_KRB5,
                 principal=None)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
@@ -495,6 +500,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
+                mech_oid=kerberos.GSS_MECH_OID_KRB5,
                 principal=None)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
@@ -545,6 +551,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
+                mech_oid=kerberos.GSS_MECH_OID_KRB5,
                 principal=None)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
@@ -565,6 +572,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
+                mech_oid=kerberos.GSS_MECH_OID_KRB5,
                 principal=None)
 
     def test_delegation(self):
@@ -609,6 +617,7 @@ class KerberosTestCase(unittest.TestCase):
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG |
                     kerberos.GSS_C_DELEG_FLAG),
+                mech_oid=kerberos.GSS_MECH_OID_KRB5,
                 principal=None
                 )
             clientStep_continue.assert_called_with("CTX", "token")
@@ -630,6 +639,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
+                mech_oid=kerberos.GSS_MECH_OID_KRB5,
                 principal="user@REALM")
 
     def test_realm_override(self):
@@ -648,6 +658,7 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
+                mech_oid=kerberos.GSS_MECH_OID_KRB5,
                 principal=None)
 
 

--- a/test_requests_kerberos.py
+++ b/test_requests_kerberos.py
@@ -125,6 +125,28 @@ class KerberosTestCase(unittest.TestCase):
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
 
+    def test_passes_correct_mech_oid(self):
+        with patch.multiple(kerberos_module_name,
+                            authGSSClientInit=clientInit_complete,
+                            authGSSClientResponse=clientResponse,
+                            authGSSClientStep=clientStep_continue):
+            response = requests.Response() #a response
+            host = 'a host'                 
+
+            auth = requests_kerberos.HTTPKerberosAuth()
+            auth.generate_request_header(response, host)
+            self.assertEqual(
+                clientInit_complete.call_args[1]['mech_oid'],
+                kerberos.GSS_MECH_OID_KRB5
+            )
+
+            auth = requests_kerberos.HTTPSpnegoAuth()
+            auth.generate_request_header(response, host)
+            self.assertEqual(
+                clientInit_complete.call_args[1]['mech_oid'],
+                kerberos.GSS_MECH_OID_SPNEGO
+            )
+
     def test_generate_request_header_init_error(self):
         with patch.multiple(kerberos_module_name,
                             authGSSClientInit=clientInit_error,


### PR DESCRIPTION
Hello,

I have added support of SPNEGO authentication  (in addition to bare Kerberos)
Switched to PyKerberos 1.1.14 and WinKerberos 0.6.0 - both now support corresponding parameters kerberos.GSS_MECH_OID_KRB5 and kerberos.GSS_MECH_OID_SPNEGO.

Could you review and merge the change?

Kind regards,
Alexey Veklov
