### PR TITLE
added pytest restriction for Python 3.3 compatibility

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 mock
-pytest
+pytest<=3.2.5
 pytest-cov
 coveralls


### PR DESCRIPTION
Need to set an upper limit for pytest so we can continue to test with Python 3.3. This should be revisited sometime in the future.