### PR TITLE
Change  pykerberos to kerberos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=1.1.0
 winkerberos >= 0.5.0; sys.platform == 'win32'
-pykerberos >= 1.1.8, < 2.0.0; sys.platform != 'win32'
+kerberos >= 1.1.8, < 2.0.0; sys.platform != 'win32'

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
     extras_require={
         ':sys_platform=="win32"': ['winkerberos>=0.5.0'],
-        ':sys_platform!="win32"': ['pykerberos>=1.1.8,<2.0.0'],
+        ':sys_platform!="win32"': ['kerberos>=1.1.8,<2.0.0'],
     },
     test_suite='test_requests_kerberos',
     tests_require=['mock'],


### PR DESCRIPTION
pykerberos package has gone on life support. changing dependency to original kerberos package. they are both same. 

> NOTE: this fork of ccs-kerberos is currently on life support mode as Apple has resumed work on upstream. Please try to use https://pypi.python.org/pypi/kerberos instead of this fork if possible.

https://github.com/02strich/pykerberos

original kerberos package maintained by apple . 
https://pypi.python.org/pypi/kerberos