### PR TITLE
Resolve URL hostname to FQDN when constructing the SPN

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,24 @@ setting the ``hostname_override`` arg:
     >>> r = requests.get("https://externalhost.example.org/", auth=kerberos_auth)
     ...
 
+If ``externalhost.example.org`` is a e.g. CNAME that can be resolved to
+``internalhost.local`` by via DNS, then you can have ``requests-kerberos``
+use the resolved version of the hostname for Kerberos by specifying the
+``canonicalize_hostname`` flag:
+
+.. code-block:: python
+
+    >>> import requests
+    >>> from requests_kerberos import HTTPKerberosAuth
+    >>> kerberos_auth = HTTPKerberosAuth(canonicalize_hostname=True)
+    >>> r = requests.get("https://externalhost.example.org/", auth=kerberos_auth)
+    ...
+
+Canonicalizing hostnames in this way is the default behaviour for almost all browsers.
+We don't match this behaviour because it can weaken security in the case where
+mutual authentication is being used over unauthenticated HTTP to validate the identity
+of the server.
+
 Explicit Principal
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -119,8 +119,8 @@ setting the ``hostname_override`` arg:
     >>> r = requests.get("https://externalhost.example.org/", auth=kerberos_auth)
     ...
 
-If ``externalhost.example.org`` is a e.g. CNAME that can be resolved to
-``internalhost.local`` by via DNS, then you can have ``requests-kerberos``
+If ``externalhost.example.org`` is a CNAME that can be resolved to
+``internalhost.local`` via DNS, then you can have ``requests-kerberos``
 use the resolved version of the hostname for Kerberos by specifying the
 ``canonicalize_hostname`` flag:
 

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -198,7 +198,8 @@ class HTTPKerberosAuth(AuthBase):
             self, mutual_authentication=REQUIRED,
             service="HTTP", delegate=False, force_preemptive=False,
             principal=None, hostname_override=None,
-            sanitize_mutual_error_response=True, send_cbt=True):
+            sanitize_mutual_error_response=True, send_cbt=True,
+            canonicalize_hostname=False):
         self.context = {}
         self.mutual_authentication = mutual_authentication
         self.delegate = delegate
@@ -207,6 +208,7 @@ class HTTPKerberosAuth(AuthBase):
         self.force_preemptive = force_preemptive
         self.principal = principal
         self.hostname_override = hostname_override
+        self.canonicalize_hostname = canonicalize_hostname
         self.sanitize_mutual_error_response = sanitize_mutual_error_response
         self.auth_done = False
         self.winrm_encryption_available = hasattr(kerberos, 'authGSSWinRMEncryptMessage')
@@ -238,8 +240,10 @@ class HTTPKerberosAuth(AuthBase):
             # w/ name-based HTTP hosting)
             if self.hostname_override is not None:
                 kerb_host = self.hostname_override
-            else:
+            elif self.canonicalize_hostname:
                 kerb_host = _get_default_kerb_host(host)
+            else:
+                kerb_host = host
             kerb_spn = "{0}@{1}".format(self.service, kerb_host)
 
             result, self.context[host] = kerberos.authGSSClientInit(kerb_spn,

--- a/tests/test_requests_kerberos.py
+++ b/tests/test_requests_kerberos.py
@@ -668,7 +668,7 @@ class KerberosTestCase(unittest.TestCase):
                 response.url = "http://www.example.org/"
                 response.headers = {'www-authenticate': 'negotiate token'}
                 host = urlparse(response.url).hostname
-                auth = requests_kerberos.HTTPKerberosAuth()
+                auth = requests_kerberos.HTTPKerberosAuth(canonicalize_hostname=True)
                 auth.generate_request_header(response, host)
                 clientInit_complete.assert_called_with(
                     "HTTP@otherhost.otherdomain.org",

--- a/tests/test_requests_kerberos.py
+++ b/tests/test_requests_kerberos.py
@@ -660,11 +660,10 @@ class KerberosTestCase(unittest.TestCase):
                             authGSSClientResponse=clientResponse,
                             authGSSClientStep=clientStep_continue):
             
-            getfqdn = socket.getfqdn
-            def getfqdn_mock(host):
-                return 'otherhost.otherdomain.org' if host == 'www.example.org' else getfqdn(host)
+            def get_host_mock(host):
+                return 'otherhost.otherdomain.org' if host == 'www.example.org' else socket.getfqdn(host)
 
-            with patch.multiple('socket', getfqdn=getfqdn_mock):
+            with patch.multiple('requests_kerberos.kerberos_', _get_default_kerb_host=get_host_mock):
                 response = requests.Response()
                 response.url = "http://www.example.org/"
                 response.headers = {'www-authenticate': 'negotiate token'}


### PR DESCRIPTION
This should resolve at least some instances of #96 and make having to supply hostname_override a much rarer proposition.