### PR TITLE
Support passing in context with delegated credentials

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,13 +147,17 @@ Delegation
 
 ``requests_kerberos`` supports credential delegation (``GSS_C_DELEG_FLAG``).
 To enable delegation of credentials to a server that requests delegation, pass
-``delegate=True`` to ``HTTPKerberosAuth``:
+``delegate=True`` and ``delegated_context=<context>`` (where context is the server
+context containing delegated credentials) to ``HTTPKerberosAuth``:
 
 .. code-block:: python
 
     >>> import requests
+    >>> import kerberos
     >>> from requests_kerberos import HTTPKerberosAuth
-    >>> r = requests.get("http://example.org", auth=HTTPKerberosAuth(delegate=True))
+    >>> result, context = kerberos.authGSSServerInit("DELEGATE")
+    >>> result = kerberos.authGSSServerStep(context, "delegated_token")
+    >>> r = requests.get("http://example.org", auth=HTTPKerberosAuth(delegate=True, delegated_context=context))
     ...
 
 Be careful to only allow delegation to servers you trust as they will be able

--- a/tests/test_requests_kerberos.py
+++ b/tests/test_requests_kerberos.py
@@ -21,7 +21,7 @@ import requests_kerberos
 import unittest
 from requests_kerberos.kerberos_ import _get_certificate_hash
 
-# kerberos.authClientInit() is called with the service name (HTTP@FQDN) and
+# kerberos.authGSSClientInit() is called with the service name (HTTP@FQDN) and
 # returns 1 and a kerberos context object on success. Returns -1 on failure.
 clientInit_complete = Mock(return_value=(1, "CTX"))
 clientInit_error = Mock(return_value=(-1, "CTX"))
@@ -596,7 +596,8 @@ class KerberosTestCase(unittest.TestCase):
             response.connection = connection
             response._content = ""
             response.raw = raw
-            auth = requests_kerberos.HTTPKerberosAuth(1, "HTTP", True)
+            delegated_context = "DELEGATED_CTX"
+            auth = requests_kerberos.HTTPKerberosAuth(1, "HTTP", True, delegated_context=delegated_context)
             r = auth.authenticate_user(response)
 
             self.assertTrue(response in r.history)
@@ -612,7 +613,8 @@ class KerberosTestCase(unittest.TestCase):
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG |
                     kerberos.GSS_C_DELEG_FLAG),
-                principal=None
+                principal=None,
+                delegated=delegated_context
                 )
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")


### PR DESCRIPTION
In order to fully support Kerberos delegation, a service should be able to authenticate with Kerberos on behalf of a user. That user's credentials can be passed in to the `delegated` parameter of `kerberos.authGSSClientInit` as documented [here](https://github.com/apple/ccs-pykerberos/blob/master/pysrc/kerberos.py#L159).

I've updated the `README` to include a scenario of how a context with delegated credentials can be initialized. Note that I pass in `"DELEGATE"` as the service principal, which is documented [here](https://github.com/apple/ccs-pykerberos/blob/master/pysrc/kerberos.py#L353).

I realized this requires users of the interface to interact with GSS API more directly, and I'm open to better ways of abstracting this away, if possible.