### PR TITLE
Fix invalid escape sequence "\s"

### DIFF
--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -82,7 +82,7 @@ def _negotiate_value(response):
     else:
         # There's no need to re-compile this EVERY time it is called. Compile
         # it once and you won't have the performance hit of the compilation.
-        regex = re.compile('(?:.*,)*\s*Negotiate\s*([^,]*),?', re.I)
+        regex = re.compile(r'(?:.*,)*\s*Negotiate\s*([^,]*),?', re.I)
         _negotiate_value.regex = regex
 
     authreq = response.headers.get('www-authenticate', None)


### PR DESCRIPTION
Mark the regex as a raw string instead.

Also-authored-by: Stanislav Levin <slev@altlinux.org>

See: https://github.com/pythongssapi/requests-gssapi/pull/10 and https://github.com/pythongssapi/requests-gssapi/issues/9