### PR TITLE
Added missing trove classifier for license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,4 +58,7 @@ setup(
     },
     test_suite='test_requests_kerberos',
     tests_require=['mock'],
+    classifiers=[
+        "License :: OSI Approved :: ISC License (ISCL)"
+    ],
 )


### PR DESCRIPTION
Now PYPI should be able to recognise license.

Fixes #122