### PR TITLE
Update requirements to use kerberos instead of pykerberos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=1.1.0
 winkerberos >= 0.5.0; sys.platform == 'win32'
-pykerberos >= 1.1.8, < 2.0.0; sys.platform != 'win32'
+kerberos >= 1.1.8, < 2.0.0; sys.platform != 'win32'
 cryptography>=1.3
 cryptography>=1.3; python_version!="3.3"
 cryptography>=1.3, <2; python_version=="3.3"

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
     extras_require={
         ':sys_platform=="win32"': ['winkerberos>=0.5.0'],
-        ':sys_platform!="win32"': ['pykerberos>=1.1.8,<2.0.0'],
+        ':sys_platform!="win32"': ['kerberos>=1.1.8,<2.0.0'],
     },
     test_suite='test_requests_kerberos',
     tests_require=['mock'],


### PR DESCRIPTION
https://github.com/02strich/pykerberos (https://pypi.org/project/pykerberos/) says
"NOTE: this fork of ccs-kerberos is currently on life support mode as Apple has resumed work on upstream.
Please try to use https://pypi.python.org/pypi/kerberos instead of this fork if possible.".
So, this PR will switch pykerberos to https://github.com/apple/ccs-pykerberos (https://pypi.org/project/kerberos/).