### PR TITLE
Try winkerberos first

### DIFF
--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -1,7 +1,7 @@
 try:
-    import kerberos
-except ImportError:
     import winkerberos as kerberos
+except ImportError:
+    import kerberos
 import logging
 import re
 import sys

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -1,10 +1,16 @@
-try:
-    import winkerberos as kerberos
-except ImportError:
-    import kerberos
+import sys
+if sys.platform in ["win32", "cygwin"]:
+    try:
+        import kerberos
+    except ImportError:
+        import winkerberos as kerberos
+else:
+    try:
+        import winkerberos as kerberos
+    except ImportError:
+        import kerberos
 import logging
 import re
-import sys
 import warnings
 
 from cryptography import x509


### PR DESCRIPTION
In the previous order, the `ImportError` is masked on Linux and leads to a confusing message about not finding the `winkerberos` which just confuses most Linux users.

This ordering lets the real issue be exposed for Linux users. Windows users are less likely to be missing pieces and there should be fewer users of this software on Windows too.