### PR TITLE
Resolve concurrency issue

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 History
 =======
 
+0.14.0.dev0: 2019-07-01
+-----------------------
+
+- Dropped winrm support. The kerberos context is now attached to response
+  objects so applications like winrm can be implemented external to
+  requests-kerberos.
+- Corrected a concurrency issue exposed by threaded applications.
+
 0.12.0: 2017-12-20
 ------------------------
 

--- a/requests_kerberos/__init__.py
+++ b/requests_kerberos/__init__.py
@@ -22,4 +22,4 @@ logging.getLogger(__name__).addHandler(NullHandler())
 
 __all__ = ('HTTPKerberosAuth', 'MutualAuthenticationError', 'REQUIRED',
            'OPTIONAL', 'DISABLED')
-__version__ = '0.13.0.dev0'
+__version__ = '0.14.0.dev0'

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -303,7 +303,7 @@ class HTTPKerberosAuth(AuthBase):
         log.debug("handle_other(): Handling: %d" % response.status_code)
 
         setattr(response, 'requests_kerberos_context',
-                self.context.get(response.request))
+                self.context.pop(response.request, None))
 
         if self.mutual_authentication in (REQUIRED, OPTIONAL) and not self.auth_done:
 

--- a/tests/test_requests_kerberos.py
+++ b/tests/test_requests_kerberos.py
@@ -115,7 +115,7 @@ class KerberosTestCase(unittest.TestCase):
             host = urlparse(response.url).hostname
             auth = requests_kerberos.HTTPKerberosAuth()
             self.assertEqual(
-                auth.generate_request_header(host, response=response),
+                auth.generate_request_header(response, host),
                 "Negotiate GSSRESPONSE"
             )
             clientInit_complete.assert_called_with(
@@ -138,7 +138,7 @@ class KerberosTestCase(unittest.TestCase):
             host = urlparse(response.url).hostname
             auth = requests_kerberos.HTTPKerberosAuth()
             self.assertRaises(requests_kerberos.exceptions.KerberosExchangeError,
-                auth.generate_request_header, host, response=response,
+                auth.generate_request_header, response, host
             )
             clientInit_error.assert_called_with(
                 "HTTP@www.example.org",
@@ -160,7 +160,7 @@ class KerberosTestCase(unittest.TestCase):
             host = urlparse(response.url).hostname
             auth = requests_kerberos.HTTPKerberosAuth()
             self.assertRaises(requests_kerberos.exceptions.KerberosExchangeError,
-                auth.generate_request_header, host, response=response,
+                auth.generate_request_header, response, host
             )
             clientInit_complete.assert_called_with(
                 "HTTP@www.example.org",
@@ -568,7 +568,7 @@ class KerberosTestCase(unittest.TestCase):
             response.headers = {'www-authenticate': 'negotiate token'}
             host = urlparse(response.url).hostname
             auth = requests_kerberos.HTTPKerberosAuth(service="barfoo")
-            auth.generate_request_header(host, response=response),
+            auth.generate_request_header(response, host)
             clientInit_complete.assert_called_with(
                 "barfoo@www.example.org",
                 gssflags=(
@@ -633,7 +633,7 @@ class KerberosTestCase(unittest.TestCase):
             response.headers = {'www-authenticate': 'negotiate token'}
             host = urlparse(response.url).hostname
             auth = requests_kerberos.HTTPKerberosAuth(principal="user@REALM")
-            auth.generate_request_header(host, response=response)
+            auth.generate_request_header(response, host)
             clientInit_complete.assert_called_with(
                 "HTTP@www.example.org",
                 gssflags=(
@@ -651,7 +651,7 @@ class KerberosTestCase(unittest.TestCase):
             response.headers = {'www-authenticate': 'negotiate token'}
             host = urlparse(response.url).hostname
             auth = requests_kerberos.HTTPKerberosAuth(hostname_override="otherhost.otherdomain.org")
-            auth.generate_request_header(host, response=response)
+            auth.generate_request_header(response, host)
             clientInit_complete.assert_called_with(
                 "HTTP@otherhost.otherdomain.org",
                 gssflags=(


### PR DESCRIPTION
Here's another go at it. The biggest differences between this and https://github.com/requests/requests-kerberos/pull/114 are:

 - The changes to generate_request_header should be less invasive.
 - We avoid the memory leak by dropping the established context (still indexed by prepared request) once we're done using it.
 - We add back the winrm functions and have them raise more helpful error messages than the attribute errors we would have raised before.
 - We document the winrm support being dropped in the history file
 - We bump the version (minor version, since we're on 0.x).