### PR TITLE
Update kerberos_.py

### DIFF
--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -207,7 +207,7 @@ class HTTPKerberosAuth(AuthBase):
             # (eg, in cases of aliased hosts, internal vs external, CNAMEs
             # w/ name-based HTTP hosting)
             kerb_host = self.hostname_override if self.hostname_override is not None else host
-            kerb_spn = "{0}@{1}".format(self.service, kerb_host)
+            kerb_spn = "{0}/{1}".format('WSMAN', kerb_host)
 
             result, self.context[host] = kerberos.authGSSClientInit(kerb_spn,
                 gssflags=gssflags, principal=self.principal)


### PR DESCRIPTION
This change let me use kinit with winrm from a RHEL7 server not in the AD domain to a Windows 10 desktop in the AD domain. Without this change I get the widely reported error "server not found in the Kerberos database". I learned that "server" actually is the computer we are attempting to connect *to*, not from. The essential bit is getting the @ replaced with /. I have a hard time believing that the @ is not a bug, because in various keytabs etc I always saw thing/host@domain. But I just needed to get winrm working, I didn't introduce myself to the workings of Kerberos.