### PR TITLE
allow user to pass in mech_oid

### DIFF
--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -168,7 +168,8 @@ class HTTPKerberosAuth(AuthBase):
             self, mutual_authentication=REQUIRED,
             service="HTTP", delegate=False, force_preemptive=False,
             principal=None, hostname_override=None,
-            sanitize_mutual_error_response=True, send_cbt=True):
+            sanitize_mutual_error_response=True, send_cbt=True,
+            mech_oid=kerberos.GSS_MECH_OID_KRB5):
         self.context = {}
         self.mutual_authentication = mutual_authentication
         self.delegate = delegate
@@ -180,6 +181,7 @@ class HTTPKerberosAuth(AuthBase):
         self.sanitize_mutual_error_response = sanitize_mutual_error_response
         self.auth_done = False
         self.winrm_encryption_available = hasattr(kerberos, 'authGSSWinRMEncryptMessage')
+        self.mech_oid=mech_oid
 
         # Set the CBT values populated after the first response
         self.send_cbt = send_cbt
@@ -210,7 +212,7 @@ class HTTPKerberosAuth(AuthBase):
             kerb_spn = "{0}@{1}".format(self.service, kerb_host)
 
             result, self.context[host] = kerberos.authGSSClientInit(kerb_spn,
-                gssflags=gssflags, principal=self.principal)
+                gssflags=gssflags, principal=self.principal, mech_oid=self.mech_oid)
 
             if result < 1:
                 raise EnvironmentError(result, kerb_stage)

--- a/tests/test_requests_kerberos.py
+++ b/tests/test_requests_kerberos.py
@@ -212,7 +212,8 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                principal=None)
+                principal=None,
+                mech_oid=kerberos.GSS_MECH_OID_KRB5)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
 

--- a/tests/test_requests_kerberos.py
+++ b/tests/test_requests_kerberos.py
@@ -123,7 +123,8 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                principal=None)
+                principal=None,
+                mech_oid=kerberos.GSS_MECH_OID_KRB5)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
 
@@ -145,7 +146,8 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                principal=None)
+                principal=None,
+                mech_oid=kerberos.GSS_MECH_OID_KRB5)
             self.assertFalse(clientStep_continue.called)
             self.assertFalse(clientResponse.called)
 
@@ -167,7 +169,8 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                principal=None)
+                principal=None,
+                mech_oid=kerberos.GSS_MECH_OID_KRB5)
             clientStep_error.assert_called_with("CTX", "token")
             self.assertFalse(clientResponse.called)
 
@@ -258,7 +261,8 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                principal=None)
+                principal=None,
+                mech_oid=kerberos.GSS_MECH_OID_KRB5)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
 
@@ -499,7 +503,8 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                principal=None)
+                principal=None,
+                mech_oid=kerberos.GSS_MECH_OID_KRB5)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
 
@@ -549,7 +554,8 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                principal=None)
+                principal=None,
+                mech_oid=kerberos.GSS_MECH_OID_KRB5)
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
 
@@ -569,7 +575,8 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                principal=None)
+                principal=None,
+                mech_oid=kerberos.GSS_MECH_OID_KRB5)
 
     def test_delegation(self):
         with patch.multiple(kerberos_module_name,
@@ -613,7 +620,8 @@ class KerberosTestCase(unittest.TestCase):
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG |
                     kerberos.GSS_C_DELEG_FLAG),
-                principal=None
+                principal=None,
+                mech_oid=kerberos.GSS_MECH_OID_KRB5
                 )
             clientStep_continue.assert_called_with("CTX", "token")
             clientResponse.assert_called_with("CTX")
@@ -634,7 +642,8 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                principal="user@REALM")
+                principal="user@REALM",
+                mech_oid=kerberos.GSS_MECH_OID_KRB5)
 
     def test_realm_override(self):
         with patch.multiple(kerberos_module_name,
@@ -652,7 +661,8 @@ class KerberosTestCase(unittest.TestCase):
                 gssflags=(
                     kerberos.GSS_C_MUTUAL_FLAG |
                     kerberos.GSS_C_SEQUENCE_FLAG),
-                principal=None)
+                principal=None,
+                mech_oid=kerberos.GSS_MECH_OID_KRB5)
 
 
 class TestCertificateHash(unittest.TestCase):


### PR DESCRIPTION
Allow the user to pass in an OID to avoid the following error:

SPNEGO negotiation token is not a NegTokenInit: OID 1.2.840.113554.1.2.2 does not match SPNEGO OID 1.3.6.1.5.5.2

passing in kerberos.GSS_MECH_OID_SPNEGO resolves this error.