### PR TITLE
Cannot Install on OSX 12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=1.1.0
 winkerberos >= 0.5.0; sys.platform == 'win32'
-pykerberos >= 1.1.8, < 2.0.0; sys.platform != 'win32'
+kerberos >= 1.3.0, < 2.0.0; sys.platform != 'win32'
 cryptography>=1.3
 cryptography>=1.3; python_version!="3.3"
 cryptography>=1.3, <2; python_version=="3.3"

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
     extras_require={
         ':sys_platform=="win32"': ['winkerberos>=0.5.0'],
-        ':sys_platform!="win32"': ['pykerberos>=1.1.8,<2.0.0'],
+        ':sys_platform!="win32"': ['kerberos>=1.3.0,<2.0.0'],
     },
     test_suite='test_requests_kerberos',
     tests_require=['mock'],


### PR DESCRIPTION
[Pykerberos](https://github.com/02strich/pykerberos) is no longer maintained and cannot be installed on OSX 12.   The repository recommends using Apple's maintained version of [pykerberos](https://github.com/apple/ccs-pykerberos), which can be installed on OSX 12.