### PR TITLE
Fix negotiate regex patter

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 - Add support for channel binding tokens (assumes pykerberos support >= 1.2.1)
 - Add support for kerberos message encryption (assumes pykerberos support >= 1.2.1)
 - Misc CI/test fixes
+- Fix Negotiate header regex pattern to avoid DoS affected patterns
 
 0.11.0: 2016-11-02
 ------------------

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -82,7 +82,7 @@ def _negotiate_value(response):
     else:
         # There's no need to re-compile this EVERY time it is called. Compile
         # it once and you won't have the performance hit of the compilation.
-        regex = re.compile(r'(?:.*,)*\s*Negotiate\s*([^,]*),?', re.I)
+        regex = re.compile(r'Negotiate\s*([^,]*)', re.I)
         _negotiate_value.regex = regex
 
     authreq = response.headers.get('www-authenticate', None)


### PR DESCRIPTION
Updates the regex pattern to avoid a DoS attack against the client trying to perpetually scan the header. This is the same change that `requests-gssapi` has implemented without any side affects so far https://github.com/pythongssapi/requests-gssapi/pull/22.

Fixes https://github.com/requests/requests-kerberos/issues/145
Fixes https://github.com/requests/requests-kerberos/issues/152