### PR TITLE
Fix stray byte conversion and added changelog

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 History
 =======
 
+0.14.0: TBD
+------------------
+
+- Added support for proxy authentication with ``HTTP`` endpoints.
+- Support for proxying ``HTTPS`` endpoints is not available due to limitations
+  of the underlying requests/urllib3 library.
+- Fixed up stray bytes to str conversion.
+
 0.13.0: 2021-11-03
 ------------------
 

--- a/requests_kerberos/__init__.py
+++ b/requests_kerberos/__init__.py
@@ -21,4 +21,4 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = ('HTTPKerberosAuth', 'MutualAuthenticationError', 'REQUIRED',
            'OPTIONAL', 'DISABLED')
-__version__ = '0.13.0'
+__version__ = '0.14.0'

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -348,13 +348,16 @@ class HTTPKerberosAuth(AuthBase):
         Returns True on success, False on failure.
         """
 
+        response_token = _negotiate_value(response)
         log.debug("authenticate_server(): Authenticate header: {0}".format(
-            _negotiate_value(response)))
+            base64.b64encode(response_token).decode()
+            if response_token
+            else ""))
 
         host = urlparse(response.url).hostname
 
         try:
-            self._context[host].step(in_token=_negotiate_value(response))
+            self._context[host].step(in_token=response_token)
         except spnego.exceptions.SpnegoError:
             log.exception("authenticate_server(): ctx step() failed:")
             return False


### PR DESCRIPTION
The raw Kerberos token from the server was being used in the debug logs which can be problematic when dealing with invalid codepoints. This PR makes sure we log the base64 value which will always contain just ASCII chars.

Also adds the changelog entry for https://github.com/requests/requests-kerberos/pull/149.

Fixes https://github.com/requests/requests-kerberos/issues/168