### PR TITLE
Add more docs on send_cbt

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,6 +26,8 @@ History
 ------------------------
 
 - Add support for channel binding tokens (assumes pykerberos support >= 1.2.1)
+- CBT is enabled by default but for older servers which might have
+  compatibility issues this can be disabled with ``send_cbt=False``.
 - Add support for kerberos message encryption (assumes pykerberos support >= 1.2.1)
 - Misc CI/test fixes
 

--- a/README.rst
+++ b/README.rst
@@ -182,3 +182,13 @@ If you are having difficulty we suggest you configure logging. Issues with the
 underlying kerberos libraries will be made apparent. Additionally, copious debug
 information is made available which may assist in troubleshooting if you
 increase your log level all the way up to debug.
+
+Channel Binding
+---------------
+
+Since ``v0.12.0`` this library automatically attempts to bind the
+authentication token with the channel binding data when connecting over a TLS
+connection. Channel Binding is also known as Extended Protection for
+Authentication (``EPA``) from Microsoft. This should be ignored by servers
+which do not implement support for CB but in the rare case this still fails it
+can be disabled by setting ``send_cbt=False``.


### PR DESCRIPTION
It was pointed out that `send_cbt` is not documented and the addition of automatic channel binding data was  not mentioned in the changelog. This PR expands the docs to further talk about this process and how it can be disabled in the case the server does not support this.

Fixes https://github.com/requests/requests-kerberos/issues/173