### PR TITLE
fix #181 add password param to constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ env/
 build/
 dist/
 requests_kerberos.egg-info/
-
+.venv
+.vscode

--- a/requests_kerberos/kerberos_.py
+++ b/requests_kerberos/kerberos_.py
@@ -210,26 +210,16 @@ class HTTPKerberosAuth(AuthBase):
             # w/ name-based HTTP hosting)
             kerb_host = self.hostname_override if self.hostname_override is not None else host
 
-            # to prevent failing compare headers test, don't pass password if None
-            if self.password:
-                self._context[host] = ctx = spnego.client(
-                    username=self.principal,
-                    password=self.password,
-                    hostname=kerb_host,
-                    service=self.service,
-                    channel_bindings=self._cbts.get(host, None),
-                    context_req=gssflags,
-                    protocol="kerberos",
-                )
-            else:
-                self._context[host] = ctx = spnego.client(
-                    username=self.principal,
-                    hostname=kerb_host,
-                    service=self.service,
-                    channel_bindings=self._cbts.get(host, None),
-                    context_req=gssflags,
-                    protocol="kerberos",
-                )
+            self._context[host] = ctx = spnego.client(
+                username=self.principal,
+                password=self.password,
+                hostname=kerb_host,
+                service=self.service,
+                channel_bindings=self._cbts.get(host, None),
+                context_req=gssflags,
+                protocol="kerberos",
+            )
+
 
             # if we have a previous response from the server, use it to continue
             # the auth process, otherwise use an empty value

--- a/tests/test_requests_kerberos.py
+++ b/tests/test_requests_kerberos.py
@@ -705,7 +705,7 @@ def test_principal_override_with_pass(mock_client):
     response.url = "http://www.example.org/"
     response.headers = {'www-authenticate': 'negotiate dG9rZW4='}
     host = urlparse(response.url).hostname
-    auth = requests_kerberos.HTTPKerberosAuth(principal="user@REALM:password")
+    auth = requests_kerberos.HTTPKerberosAuth(principal="user@REALM",password="password")
     auth.generate_request_header(response, host),
 
     assert mock_client.call_count == 1

--- a/tests/test_requests_kerberos.py
+++ b/tests/test_requests_kerberos.py
@@ -700,6 +700,25 @@ def test_principal_override(mock_client):
         "protocol": "kerberos",
     }
 
+def test_principal_override_with_pass(mock_client):
+    response = requests.Response()
+    response.url = "http://www.example.org/"
+    response.headers = {'www-authenticate': 'negotiate dG9rZW4='}
+    host = urlparse(response.url).hostname
+    auth = requests_kerberos.HTTPKerberosAuth(principal="user@REALM:password")
+    auth.generate_request_header(response, host),
+
+    assert mock_client.call_count == 1
+    assert mock_client.call_args[1] == {
+        "username": "user@REALM",
+        "password": "password",
+        "hostname": "www.example.org",
+        "service": "HTTP",
+        "channel_bindings": None,
+        "context_req": spnego.ContextReq.sequence_detect | spnego.ContextReq.mutual_auth,
+        "protocol": "kerberos",
+    }
+
 
 def test_realm_override(mock_client):
     response = requests.Response()

--- a/tests/test_requests_kerberos.py
+++ b/tests/test_requests_kerberos.py
@@ -72,6 +72,7 @@ def test_generate_request_header(mock_client):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "www.example.org",
         "service": "HTTP",
         "channel_bindings": None,
@@ -99,6 +100,7 @@ def test_generate_request_header_init_error(mock_client):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "www.example.org",
         "service": "HTTP",
         "channel_bindings": None,
@@ -123,6 +125,7 @@ def test_generate_request_header_step_error(mock_client):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "www.example.org",
         "service": "HTTP",
         "channel_bindings": None,
@@ -169,6 +172,7 @@ def test_authenticate_user(mock_client, mocker):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "www.example.org",
         "service": "HTTP",
         "channel_bindings": None,
@@ -217,6 +221,7 @@ def test_authenticate_user2(mock_client, mocker):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "www.example.org",
         "service": "HTTP",
         "channel_bindings": None,
@@ -262,6 +267,7 @@ def test_handle_401(mock_client, mocker):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "www.example.org",
         "service": "HTTP",
         "channel_bindings": None,
@@ -310,6 +316,7 @@ def test_handle_407(mock_client, mocker):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "www.example.org",
         "service": "HTTP",
         "channel_bindings": None,
@@ -553,6 +560,7 @@ def test_handle_response_401(mock_client, mocker):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "www.example.org",
         "service": "HTTP",
         "channel_bindings": None,
@@ -606,6 +614,7 @@ def test_handle_response_401_rejected(mock_client, mocker):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "www.example.org",
         "service": "HTTP",
         "channel_bindings": None,
@@ -630,6 +639,7 @@ def test_generate_request_header_custom_service(mock_client):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "www.example.org",
         "service": "barfoo",
         "channel_bindings": None,
@@ -669,6 +679,7 @@ def test_delegation(mock_client, mocker):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "www.example.org",
         "service": "HTTP",
         "channel_bindings": None,
@@ -693,6 +704,7 @@ def test_principal_override(mock_client):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": "user@REALM",
+        "password": None,
         "hostname": "www.example.org",
         "service": "HTTP",
         "channel_bindings": None,
@@ -731,6 +743,7 @@ def test_realm_override(mock_client):
     assert mock_client.call_count == 1
     assert mock_client.call_args[1] == {
         "username": None,
+        "password": None,
         "hostname": "otherhost.otherdomain.org",
         "service": "HTTP",
         "channel_bindings": None,


### PR DESCRIPTION
Hi,

This pull request is for parsing the principal if it is given in the form of user@REALM:password. It will split the username and password and pass them both to spnego.client().