### PR TITLE
Implement DNS hostname canonicalization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,25 @@ To enable delegation of credentials to a server that requests delegation, pass
 Be careful to only allow delegation to servers you trust as they will be able
 to impersonate you using the delegated credentials.
 
+Hostname canonicalization
+-------------------------
+
+When one or more services run on a single host and CNAME records are employed
+to point at the host's A or AAAA records, and there is an SPN only for the canonical
+name of the host, different hostname needs to be used for an HTTP request
+and differnt for authentication. To enable canonical name resolution pass
+``dns_canonicalize_hostname=True`` to ``HTTPSPNEGOAuth``. Optionally,
+if ``use_reverse_dns=True`` is passed, an additional reverse DNS lookup
+will be used to obtain the canonical name.
+
+.. code-block:: python
+
+    >>> import requests
+    >>> from requests_kerberos import HTTPKerberosAuth
+    >>> kerberos_auth = HTTPKerberosAuth(dns_canonicalize_hostname=True, use_reverse_dns=True)
+    >>> r = requests.get("http://example.org", auth=kerberos_auth)
+    ...
+
 Logging
 -------
 


### PR DESCRIPTION
Optionally resolve hostname via CNAME recrord to its canonical form (A or AAAA record). Optionally use reverse DNS query.

Such code is necessary on Windows platforms where SSPI (unlike MIT Kerberos[1]) does not implement such operation and it is applications' responsibility[2] to take care of CNAME resolution. However, the code seems universal enough to put it into the library rather than in every single program using requests_kerberos.

[1] https://github.com/krb5/krb5/blob/ec71ac1cabbb3926f8ffaf71e1ad007e4e56e0e5/src/lib/krb5/os/sn2princ.c#L99
[2] https://learn.microsoft.com/en-us/previous-versions/office/sharepoint-server-2010/gg502606(v=office.14)?redirectedfrom=MSDN#kerberos-authentication-and-dns-cnames