### PR TITLE
Update readme and prepare for v0.15.0 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 History
 =======
 
+0.15.0: 2024-06-04
+------------------
+
+- Make Channel Binding data per-host
+- Added support for explicit passwords using the ``password`` kwarg
+
 0.14.0: 2021-12-05
 ------------------
 

--- a/requests_kerberos/__init__.py
+++ b/requests_kerberos/__init__.py
@@ -21,4 +21,4 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = ('HTTPKerberosAuth', 'MutualAuthenticationError', 'REQUIRED',
            'OPTIONAL', 'DISABLED')
-__version__ = '0.14.0'
+__version__ = '0.15.0'


### PR DESCRIPTION
Bumps the version to `0.15.0` and updates the README to cover system dependencies and the new `password` argument.

Fixes: https://github.com/requests/requests-kerberos/issues/175