### PR TITLE
Update CI to include Python 3.11, 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,13 @@ jobs:
           image: python:3.9-slim
         - python-version: '3.10'
           image: python:3.10-slim
+        - python-version: '3.11'
+          image: python:3.11-slim
+        - python-version: '3.12'
+          image: python:3.12-slim
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Run tests
       shell: bash
@@ -64,10 +68,10 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
 
     - name: Installing baseline packages
       run: |
@@ -78,13 +82,13 @@ jobs:
       run: python setup.py sdist bdist_wheel
 
     - name: Capture Wheel and SDist
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: artifact
         path: dist/*
 
     - name: Publish
-      if: startsWith(github.ref, 'refs/tags/v')
+      if: startsWith(github.event.release.tag_name, 'v')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__


### PR DESCRIPTION
Also updates the CI action versions to use the non-deprecated node version.